### PR TITLE
docs: add Floatboat Combo Skill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Free for personal, educational and non-commercial use. Commercial use requires p
 
 The skill includes the complete prompt in both Chinese and English.
 
+## 支持的智能体
+
+| 智能体 | 安装 / 使用 |
+| --- | --- |
+| OpenAI Codex | 将此文件夹复制到 `~/.codex/skills/`，上传一张照片后，请 Codex 使用 `photo-abstract-editorial`。 |
+| [Floatboat](https://floatboat.ai/zh/combostore/photo-abstract-editorial-1MTHgw) | 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-1MTHgw) 安装 **photo-abstract-editorial**，上传一张照片后运行该 Combo Skill。 |
+
 ## 示例图片（原图均为本人拍摄）
 
 <!-- <table>
@@ -42,6 +49,14 @@ The skill includes the complete prompt in both Chinese and English.
    > 使用 `photo-abstract-editorial` 将这张照片制作成摄影与抽象面板组合的编辑作品。
 
 4. Skill 会将原图保留在成品的上方或主要区域，并在下方创建由原图关系推导出的极简抽象面板。成品中只保留一个原创英文标题（可选副标题）。
+
+### 在 Floatboat 中使用
+
+1. 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-1MTHgw) 安装 **photo-abstract-editorial**。
+2. 新建对话并上传一张希望处理的照片。
+3. 运行 **photo-abstract-editorial** Combo Skill，生成“原始摄影区域 + 抽象记忆面板 + 英文标题”的编辑作品。
+
+无需手动复制 Skill 文件或粘贴提示词。
 
 也可以直接打开下列文件，并将其作为图像生成提示词使用：
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The skill includes the complete prompt in both Chinese and English.
 | 智能体 | 安装 / 使用 |
 | --- | --- |
 | OpenAI Codex | 将此文件夹复制到 `~/.codex/skills/`，上传一张照片后，请 Codex 使用 `photo-abstract-editorial`。 |
-| [Floatboat](https://floatboat.ai/zh/combostore/photo-abstract-editorial-1MTHgw) | 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-1MTHgw) 安装 **photo-abstract-editorial**，上传一张照片后运行该 Combo Skill。 |
+| [Floatboat](https://floatboat.ai/zh/combostore/photo-abstract-editorial-3AtFwG) | 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-3AtFwG) 安装 **photo-abstract-editorial**，上传一张照片后运行该 Combo Skill。 |
 
 ## 示例图片（原图均为本人拍摄）
 
@@ -52,7 +52,7 @@ The skill includes the complete prompt in both Chinese and English.
 
 ### 在 Floatboat 中使用
 
-1. 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-1MTHgw) 安装 **photo-abstract-editorial**。
+1. 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-3AtFwG) 安装 **photo-abstract-editorial**。
 2. 新建对话并上传一张希望处理的照片。
 3. 运行 **photo-abstract-editorial** Combo Skill，生成“原始摄影区域 + 抽象记忆面板 + 英文标题”的编辑作品。
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The skill includes the complete prompt in both Chinese and English.
 | 智能体 | 安装 / 使用 |
 | --- | --- |
 | OpenAI Codex | 将此文件夹复制到 `~/.codex/skills/`，上传一张照片后，请 Codex 使用 `photo-abstract-editorial`。 |
-| [Floatboat](https://floatboat.ai/zh/combostore/photo-abstract-editorial-3AtFwG) | 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-3AtFwG) 安装 **photo-abstract-editorial**，上传一张照片后运行该 Combo Skill。 |
+| [Floatboat](https://floatboat.ai/zh/combostore/photo-abstract-editorial-2j4IyK) | 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-2j4IyK) 安装 **photo-abstract-editorial**，上传一张照片后运行该 Combo Skill。 |
 
 ## 示例图片（原图均为本人拍摄）
 
@@ -52,7 +52,7 @@ The skill includes the complete prompt in both Chinese and English.
 
 ### 在 Floatboat 中使用
 
-1. 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-3AtFwG) 安装 **photo-abstract-editorial**。
+1. 从 [Floatboat Combo Skill Store](https://floatboat.ai/zh/combostore/photo-abstract-editorial-2j4IyK) 安装 **photo-abstract-editorial**。
 2. 新建对话并上传一张希望处理的照片。
 3. 运行 **photo-abstract-editorial** Combo Skill，生成“原始摄影区域 + 抽象记忆面板 + 英文标题”的编辑作品。
 


### PR DESCRIPTION
## Summary

This PR adds Floatboat support documentation for `photo-abstract-editorial`.

Users can now discover, install, and run the skill directly from the Floatboat Combo Skill Store without manually copying Skill files or pasting the full prompt.

## Changes

- Add Floatboat to the supported agent table in `README.md`
- Add a dedicated **Using in Floatboat** section
- Document the installation and usage flow for `photo-abstract-editorial`
- Update all Floatboat Combo Store references to the current URL

  https://floatboat.ai/zh/combostore/photo-abstract-editorial-2j4IyK

## In-App Evidence

The following screenshots demonstrate the skill running inside Floatboat and the generated editorial outputs.

| Floatboat in-app run | Generated output |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Link-990/photo-abstract-editorial/demo/floatboat-in-app-evidence/assets/floatboat-demo/floatboat-in-app-run-blue-before-daybreak.png" alt="Photo Abstract Editorial running in Floatboat with Blue Before Daybreak" width="440"> | <img src="https://raw.githubusercontent.com/Link-990/photo-abstract-editorial/demo/floatboat-in-app-evidence/assets/floatboat-demo/blue-before-daybreak-output.png" alt="Blue Before Daybreak output" width="260"> |
| <img src="https://raw.githubusercontent.com/Link-990/photo-abstract-editorial/demo/floatboat-in-app-evidence/assets/floatboat-demo/floatboat-in-app-run-morning-at-the-ridge.jpg" alt="Photo Abstract Editorial running in Floatboat with Morning At The Ridge" width="440"> | <img src="https://raw.githubusercontent.com/Link-990/photo-abstract-editorial/demo/floatboat-in-app-evidence/assets/floatboat-demo/morning-at-the-ridge-output.png" alt="Morning At The Ridge output" width="260"> |

## Validation

- Confirmed that the README no longer contains the previous Floatboat Combo Store URL
- Confirmed that the current Combo Store URL is used consistently in all 3 relevant README references
- Confirmed that this change only updates documentation
- No changes to the Skill workflow, prompts, code, example assets, or existing Codex instructions

## Scope and Compatibility

- Modified file: `README.md`
- Change type: documentation only
- Runtime impact: none
- Backward compatibility: unchanged

Existing OpenAI Codex installation and usage instructions remain unchanged.

## Notes

The screenshots above are hosted on the fork's dedicated evidence branch:

`Link-990:demo/floatboat-in-app-evidence`

This branch is used only to host PR demonstration assets. It is not part of the implementation branch and should not be merged into the upstream repository.